### PR TITLE
🔧 Configure SMTPSecure using the encryption config (Fixes #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ SMTP credentials can be found in the published `mail.php` config file and defaul
 
 ## Usage
 
-For most configurations, you can simply set the following environment variables:
+For most configurations, you can simply set the following variables in your environment:
 
 ```env
 MAIL_HOST=
@@ -40,6 +40,12 @@ MAIL_USERNAME=
 MAIL_PASSWORD=
 MAIL_FROM_ADDRESS=
 MAIL_FROM_NAME=
+```
+
+If you need to change the default encryption from `tls`, you can set the encryption variable:
+
+```env
+MAIL_ENCRYPTION=ssl
 ```
 
 Once the credentials are properly configured, you can send a test email using Acorn's CLI:

--- a/src/AcornMail.php
+++ b/src/AcornMail.php
@@ -58,6 +58,7 @@ class AcornMail
             $mail->Username = $this->config->get('username');
             $mail->Password = $this->config->get('password');
             $mail->Timeout = $this->config->get('timeout', $mail->Timeout);
+            $mail->SMTPSecure = $this->config->get('encryption', $mail->SMTPSecure);
 
             $mail->setFrom(
                 $this->fromAddress(),

--- a/src/Console/Commands/MailTestCommand.php
+++ b/src/Console/Commands/MailTestCommand.php
@@ -28,7 +28,7 @@ class MailTestCommand extends Command
     protected array $errors = [];
 
     /**
-     * The relevant mail options.
+     * The mail options.
      */
     protected array $options = [
         'From' => 'From',

--- a/src/Console/Commands/MailTestCommand.php
+++ b/src/Console/Commands/MailTestCommand.php
@@ -23,11 +23,24 @@ class MailTestCommand extends Command
     protected $description = 'Test the WordPress SMTP mailer';
 
     /**
-     * The error collection.
-     *
-     * @var \Illuminate\Support\Collection
+     * The mail errors.
      */
-    protected $errors = [];
+    protected array $errors = [];
+
+    /**
+     * The relevant mail options.
+     */
+    protected array $options = [
+        'From' => 'From',
+        'FromName' => 'From Name',
+        'Host' => 'Host',
+        'Password' => 'Password',
+        'Port' => 'Port',
+        'SMTPSecure' => 'Encryption',
+        'Subject' => 'Subject',
+        'Timeout' => 'Timeout',
+        'Username' => 'Username',
+    ];
 
     /**
      * Execute the console command.
@@ -49,9 +62,9 @@ class MailTestCommand extends Command
             $phpmailer->Debugoutput = fn ($error) => $instance->errors[] = $error;
 
             $config = collect($phpmailer)
-                ->filter(fn ($value, $key) => in_array($key, ['Host', 'Port', 'Username', 'Password', 'Timeout', 'FromName', 'From', 'Subject']))
+                ->filter(fn ($value, $key) => in_array($key, array_keys($this->options)))
                 ->map(fn ($value, $key) => $key === 'Password' ? Str::mask($value, '*', 0) : $value)
-                ->map(fn ($value, $key) => "{$key}: ".((is_null($value) || empty($value)) ? 'Not set' : "<fg=blue>{$value}</>"));
+                ->map(fn ($value, $key) => Str::finish($this->options[$key], ': ').(is_null($value) || empty($value) ? 'Not set' : "<fg=blue>{$value}</>"));
 
             $this->components->bulletList($config);
         });
@@ -78,21 +91,21 @@ class MailTestCommand extends Command
             return;
         }
 
-        $this->errors = collect($this->errors)
+        $errors = collect($this->errors)
             ->filter(fn ($error) => Str::startsWith($error, 'SMTP Error: '));
 
-        if ($this->errors->isEmpty()) {
+        if ($errors->isEmpty()) {
             $this->components->error('The test email failed to send.');
 
             return;
         }
 
-        $this->errors = $this->errors
+        $errors = $errors
             ->map(fn ($error) => "  {$error}")
             ->map(fn ($error) => str_replace("\n", "\n  ", $error));
 
         $this->components->error('The test email failed to send. The following errors were encountered:');
-        $this->line($this->errors->first());
+        $this->line($errors->first());
     }
 
     /**


### PR DESCRIPTION
## Change log

### Enhancements

- 🔧 Configure `SMTPSecure` using the `encryption` config (Fixes #8)
- 📝 Add instructions for changing the encryption variable
- 🎨 Improve the `mail:test` command output