### PR TITLE
Make subject and body configurable through option

### DIFF
--- a/src/Console/Commands/MailTestCommand.php
+++ b/src/Console/Commands/MailTestCommand.php
@@ -13,7 +13,9 @@ class MailTestCommand extends Command
      * @var string
      */
     protected $signature = 'mail:test
-                            {--to= : The email address to send the test email to.}';
+                            {--to= : The email address to send the test email to.}
+                            {--subject=Test email : The subject of the test email}
+                            {--body=This is a test email from WordPress. : The body of the test email}';
 
     /**
      * The console command description.
@@ -81,8 +83,8 @@ class MailTestCommand extends Command
 
         $mail = wp_mail(
             $recipient,
-            'Test Email',
-            'This is a test email from WordPress.'
+            $this->option('subject'),
+            $this->option('body')
         );
 
         if ($mail) {


### PR DESCRIPTION
You can now set the email subject (`--subject=`) and body (`--body=`) from the command line. This enabled us to add a the `mail:test` command to our deployment proces, and add rules in our inbox to route the test emails